### PR TITLE
Add doc comments to generated code

### DIFF
--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -12,15 +12,19 @@ namespace Generator.Equals
 
             sb.AppendLine("#nullable enable");
 
+            sb.AppendLine(EqualsOperatorCodeComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine($"public static bool operator ==({symbolName}? a, {symbolName}? b) => global::System.Collections.Generic.EqualityComparer<{symbolName}>.Default.Equals(a, b);");
-            
+
+            sb.AppendLine(NotEqualsOperatorCodeComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine($"public static bool operator !=({symbolName}? a, {symbolName}? b) => !(a == b);");
-            
+
+            sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine($"public override bool Equals(object? obj) => Equals(obj as {symbolName});");
-            
+
+            sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine($"public bool Equals({symbolName}? other) {{");
 
@@ -45,6 +49,7 @@ namespace Generator.Equals
 
             sb.AppendLine("#nullable enable");
 
+            sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine(@"public override int GetHashCode() {
                 var hashCode = new global::System.HashCode();

--- a/Generator.Equals/EqualityGeneratorBase.cs
+++ b/Generator.Equals/EqualityGeneratorBase.cs
@@ -8,6 +8,22 @@ namespace Generator.Equals
     {
         protected const string GeneratedCodeAttributeDeclaration = "[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Generator.Equals\", \"1.0.0.0\")]";
 
+        protected const string EqualsOperatorCodeComment = @"/// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name=""left"">The left object</param>
+        /// <param name=""right"">The right object</param>
+        /// <returns>true if the current object is equal to the other parameter; otherwise, false.</returns>";
+
+        protected const string NotEqualsOperatorCodeComment = @"/// <summary>
+        /// Indicates whether the current object is not equal to another object of the same type.
+        /// </summary>
+        /// <param name=""left"">The left object</param>
+        /// <param name=""right"">The right object</param>
+        /// <returns>true if the current object is not equal to the other parameter; otherwise, false.</returns>";
+
+        protected const string InheritDocComment = "/// <inheritdoc/>";
+
         public static void BuildPropertyEquality(AttributesMetadata attributesMetadata, StringBuilder sb,
             IPropertySymbol property)
         {

--- a/Generator.Equals/RecordEqualityGenerator.cs
+++ b/Generator.Equals/RecordEqualityGenerator.cs
@@ -11,7 +11,8 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
+
+            sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine(symbol.IsSealed
                 ? $"public bool Equals({symbolName}? other) {{"
@@ -42,7 +43,8 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
+
+            sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine(@"public override int GetHashCode() {
                 var hashCode = new global::System.HashCode();


### PR DESCRIPTION
Added generated doc comments and inherit doc for inherited members.

The generated comments are always the same but since equals and not equals should always do the same thing this should be okay.

closes #9 