### PR TITLE
#19: Add pragma to suppress obsolete warnings

### DIFF
--- a/Generator.Equals.Tests/Classes/ObsoleteClass.cs
+++ b/Generator.Equals.Tests/Classes/ObsoleteClass.cs
@@ -4,40 +4,18 @@ using System;
 namespace Generator.Equals.Tests.Classes
 {
     [TestFixture]
-    public partial class ObsoleteMembers
+    public partial class ObsoleteClass
     {
-        // DO NOT ADD [Obsolete] TO THIS MODEL. It would suppress the obsoletes on the properties by itself.
-        // This is why there is a separate ObsoleteClass test.
         [Equatable]
+        [Obsolete("Make sure the obsolete on the object model does not add warnings")]
         public partial class Data
         {
             public Data(string value)
             {
-#pragma warning disable CS0612
-                NoComment = value;
-#pragma warning restore CS0612
-#pragma warning disable CS0618
-                Comment = value;
-#pragma warning restore CS0618
-                // This pragma does not work, and didn't work in the generator either.
-// #pragma warning disable CS0619
-//                 CommentAndError = value;
-// #pragma warning restore CS0619
+                Something = value;
             }
 
-            [Obsolete]
-            public string NoComment { get; }
-
-            [Obsolete("Having a comment causes a different error code")]
-            public string Comment { get; }
-
-            // Could not find a way to suppress this
-            // [Obsolete("Having a comment and IsError causes a different error code", true)]
-            // public string? CommentAndError { get; }
-            //
-            // No idea what to do with this
-            // [Obsolete(DiagnosticId = "CUSTOM0001")]
-            // public string? OtherDiagnosticCode { get; }
+            public string Something { get; }
         }
 
 #pragma warning disable CS0618

--- a/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using System;
+
+namespace Generator.Equals.Tests.Classes
+{
+    [TestFixture]
+    public partial class ObsoleteMembers
+    {
+        [Equatable]
+        public partial class Data
+        {
+            public Data(string value)
+            {
+#pragma warning disable CS0612
+                NoComment = value;
+#pragma warning restore CS0612
+#pragma warning disable CS0618
+                Comment = value;
+#pragma warning restore CS0618
+                // Could not find a way to suppress this
+// #pragma warning disable CS0619
+                // CommentAndError = value;
+// #pragma warning restore CS0619
+            }
+
+            [Obsolete]
+            public string NoComment { get; }
+
+            [Obsolete("Having a comment causes a different error code")]
+            public string Comment { get; }
+
+            // Could not find a way to suppress this
+            // [Obsolete("Having a comment and IsError causes a different error code", true)]
+            // public string CommentAndError { get; }
+        }
+
+        [TestFixture]
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Data("Dave");
+            public override object Factory2() => new Data("Dave");
+            public override bool EqualsOperator(object value1, object value2) => (Data) value1 == (Data) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data) value1 != (Data) value2;
+        }
+
+        [TestFixture]
+        public  class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Data("Dave");
+            public override object Factory2() => new Data("John");
+            public override bool EqualsOperator(object value1, object value2) => (Data) value1 == (Data) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data) value1 != (Data) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
@@ -7,6 +7,7 @@ namespace Generator.Equals.Tests.Classes
     public partial class ObsoleteMembers
     {
         [Equatable]
+        [Obsolete("Make sure the warning on the object model does not add warnings")]
         public partial class Data
         {
             public Data(string value)
@@ -34,6 +35,7 @@ namespace Generator.Equals.Tests.Classes
             // public string CommentAndError { get; }
         }
 
+#pragma warning disable CS0618
         [TestFixture]
         public class EqualsTest : EqualityTestCase
         {
@@ -52,5 +54,6 @@ namespace Generator.Equals.Tests.Classes
             public override bool EqualsOperator(object value1, object value2) => (Data) value1 == (Data) value2;
             public override bool NotEqualsOperator(object value1, object value2) => (Data) value1 != (Data) value2;
         }
+#pragma warning restore CS0618
     }
 }

--- a/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Classes/ObsoleteMembers.cs
@@ -40,7 +40,6 @@ namespace Generator.Equals.Tests.Classes
             // public string? OtherDiagnosticCode { get; }
         }
 
-#pragma warning disable CS0618
         [TestFixture]
         public class EqualsTest : EqualityTestCase
         {
@@ -59,6 +58,5 @@ namespace Generator.Equals.Tests.Classes
             public override bool EqualsOperator(object value1, object value2) => (Data) value1 == (Data) value2;
             public override bool NotEqualsOperator(object value1, object value2) => (Data) value1 != (Data) value2;
         }
-#pragma warning restore CS0618
     }
 }

--- a/Generator.Equals.Tests/Records/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Records/ObsoleteMembers.cs
@@ -6,9 +6,17 @@ namespace Generator.Equals.Tests.Records
     [TestFixture]
     public partial class ObsoleteMembers
     {
+        // DO NOT ADD [Obsolete] TO THIS MODEL. It would suppress the obsoletes on the properties by itself.
+        // This is why there is a separate ObsoleteRecord test.
         [Equatable]
-        [Obsolete("Make sure the warning on the object model does not add warnings")]
-        public partial record Data([property: Obsolete] string NoComment, [property: Obsolete("a comment")] string Comment);
+        public partial record Data(
+            [property: Obsolete] string NoComment
+            , [property: Obsolete("a comment")] string Comment
+            // Could not find a way to suppress this
+            // , [property: Obsolete("a comment", true)] string CommentAndError = ""
+            // No idea what to do with this
+            // , [property: Obsolete(DiagnosticId = "CUSTOM0001")] string OtherDiagnosticCode = ""
+            );
 
 #pragma warning disable CS0618
         [TestFixture]

--- a/Generator.Equals.Tests/Records/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Records/ObsoleteMembers.cs
@@ -7,8 +7,10 @@ namespace Generator.Equals.Tests.Records
     public partial class ObsoleteMembers
     {
         [Equatable]
+        [Obsolete("Make sure the warning on the object model does not add warnings")]
         public partial record Data([property: Obsolete] string NoComment, [property: Obsolete("a comment")] string Comment);
 
+#pragma warning disable CS0618
         [TestFixture]
         public class EqualsTest : EqualityTestCase
         {
@@ -27,5 +29,6 @@ namespace Generator.Equals.Tests.Records
             public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
             public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
         }
+#pragma warning restore CS0618
     }
 }

--- a/Generator.Equals.Tests/Records/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Records/ObsoleteMembers.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using System;
+
+namespace Generator.Equals.Tests.Records
+{
+    [TestFixture]
+    public partial class ObsoleteMembers
+    {
+        [Equatable]
+        public partial record Data([property: Obsolete] string NoComment, [property: Obsolete("a comment")] string Comment);
+
+        [TestFixture]
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Data("Dave", "Smith");
+            public override object Factory2() => new Data("Dave", "Smith");
+            public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+        }
+
+        [TestFixture]
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Data("Dave", "West");
+            public override object Factory2() => new Data("John", "Smith");
+            public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/Records/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/Records/ObsoleteMembers.cs
@@ -18,7 +18,6 @@ namespace Generator.Equals.Tests.Records
             // , [property: Obsolete(DiagnosticId = "CUSTOM0001")] string OtherDiagnosticCode = ""
             );
 
-#pragma warning disable CS0618
         [TestFixture]
         public class EqualsTest : EqualityTestCase
         {
@@ -37,6 +36,5 @@ namespace Generator.Equals.Tests.Records
             public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
             public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
         }
-#pragma warning restore CS0618
     }
 }

--- a/Generator.Equals.Tests/Records/ObsoleteRecord.cs
+++ b/Generator.Equals.Tests/Records/ObsoleteRecord.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using System;
+
+namespace Generator.Equals.Tests.Records
+{
+    [TestFixture]
+    public partial class ObsoleteRecord
+    {
+        [Equatable]
+        [Obsolete("Make sure the obsolete on the object model does not add warnings")]
+        public partial record Data(string Name);
+
+#pragma warning disable CS0618
+        [TestFixture]
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Data("Dave");
+            public override object Factory2() => new Data("Dave");
+            public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+        }
+
+        [TestFixture]
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Data("Dave");
+            public override object Factory2() => new Data("John");
+            public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+        }
+#pragma warning restore CS0618
+    }
+}

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -51,9 +51,7 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
-            // Obsolete with no comment, obsolete with comment
-            sb.AppendLine("#pragma warning disable CS0612,CS0618");
+            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -73,7 +71,7 @@ namespace Generator.Equals
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
 
-            sb.AppendLine("#pragma warning restore CS0612,CS0618");
+            sb.AppendLine(RestoreObsoleteWarningsPragma);
             sb.AppendLine("#nullable restore");
         }
         

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Microsoft.CodeAnalysis;
+using System;
 
 namespace Generator.Equals
 {
@@ -11,6 +12,9 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
+            
+            // Obsolete with no comment, obsolete with comment
+            sb.AppendLine("#pragma warning disable CS0612,CS0618");
 
             sb.AppendLine(EqualsOperatorCodeComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -40,6 +44,7 @@ namespace Generator.Equals
             sb.AppendLine(";");
             sb.AppendLine("}");
 
+            sb.AppendLine("#pragma warning restore CS0612,CS0618");
             sb.AppendLine("#nullable restore");
         }
 
@@ -48,6 +53,9 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
+            
+            // Obsolete with no comment, obsolete with comment
+            sb.AppendLine("#pragma warning disable CS0612,CS0618");
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -67,6 +75,7 @@ namespace Generator.Equals
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
 
+            sb.AppendLine("#pragma warning restore CS0612,CS0618");
             sb.AppendLine("#nullable restore");
         }
         

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -12,9 +12,7 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
-            // Obsolete with no comment, obsolete with comment
-            sb.AppendLine("#pragma warning disable CS0612,CS0618");
+            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(EqualsOperatorCodeComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -44,7 +42,7 @@ namespace Generator.Equals
             sb.AppendLine(";");
             sb.AppendLine("}");
 
-            sb.AppendLine("#pragma warning restore CS0612,CS0618");
+            sb.AppendLine(RestoreObsoleteWarningsPragma);
             sb.AppendLine("#nullable restore");
         }
 

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -11,9 +11,6 @@ namespace Generator.Equals
             var symbolName = symbol.ToFQF();
             var baseTypeName = symbol.BaseType?.ToFQF();
 
-            sb.AppendLine("#nullable enable");
-            sb.AppendLine(SuppressObsoleteWarningsPragma);
-
             sb.AppendLine(EqualsOperatorCodeComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine($"public static bool operator ==({symbolName}? left, {symbolName}? right) => global::System.Collections.Generic.EqualityComparer<{symbolName}?>.Default.Equals(left, right);");
@@ -41,17 +38,11 @@ namespace Generator.Equals
 
             sb.AppendLine(";");
             sb.AppendLine("}");
-
-            sb.AppendLine(RestoreObsoleteWarningsPragma);
-            sb.AppendLine("#nullable restore");
         }
 
         static void BuildGetHashCode(ITypeSymbol symbol, AttributesMetadata attributesMetadata, StringBuilder sb)
         {
             var baseTypeName = symbol.BaseType?.ToFQF();
-
-            sb.AppendLine("#nullable enable");
-            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -70,9 +61,6 @@ namespace Generator.Equals
 
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
-
-            sb.AppendLine(RestoreObsoleteWarningsPragma);
-            sb.AppendLine("#nullable restore");
         }
         
         public static string Generate(ITypeSymbol symbol, AttributesMetadata attributesMetadata)
@@ -82,8 +70,14 @@ namespace Generator.Equals
                 var typeName = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                 sb.AppendLine($"partial class {typeName} : global::System.IEquatable<{typeName}> {{");
 
+                sb.AppendLine(EnableNullableContext);
+                sb.AppendLine(SuppressObsoleteWarningsPragma);
+
                 BuildEquals(symbol, attributesMetadata, sb);
                 BuildGetHashCode(symbol, attributesMetadata, sb);
+
+                sb.AppendLine(RestoreObsoleteWarningsPragma);
+                sb.AppendLine(RestoreNullableContext);
 
                 sb.AppendLine("}");
             });

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using Microsoft.CodeAnalysis;
-using System;
 
 namespace Generator.Equals
 {

--- a/Generator.Equals/EqualityGeneratorBase.cs
+++ b/Generator.Equals/EqualityGeneratorBase.cs
@@ -10,7 +10,11 @@ namespace Generator.Equals
     {
         protected const string GeneratedCodeAttributeDeclaration = "[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Generator.Equals\", \"1.0.0.0\")]";
 
-        // Obsolete with no comment + obsolete with comment
+        protected const string EnableNullableContext = "#nullable enable";
+        protected const string RestoreNullableContext = "#nullable restore";
+
+        // CS0612: Obsolete with no comment
+        // CS0618: obsolete with comment
         protected const string SuppressObsoleteWarningsPragma = "#pragma warning disable CS0612,CS0618";
         protected const string RestoreObsoleteWarningsPragma = "#pragma warning restore CS0612,CS0618";
 

--- a/Generator.Equals/EqualityGeneratorBase.cs
+++ b/Generator.Equals/EqualityGeneratorBase.cs
@@ -10,6 +10,10 @@ namespace Generator.Equals
     {
         protected const string GeneratedCodeAttributeDeclaration = "[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Generator.Equals\", \"1.0.0.0\")]";
 
+        // Obsolete with no comment + obsolete with comment
+        protected const string SuppressObsoleteWarningsPragma = "#pragma warning disable CS0612,CS0618";
+        protected const string RestoreObsoleteWarningsPragma = "#pragma warning restore CS0612,CS0618";
+
         protected const string EqualsOperatorCodeComment = @"/// <summary>
         /// Indicates whether the object on the left is equal to the object on the right.
         /// </summary>

--- a/Generator.Equals/RecordEqualityGenerator.cs
+++ b/Generator.Equals/RecordEqualityGenerator.cs
@@ -11,6 +11,9 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
+            
+            // Obsolete with no comment, obsolete with comment
+            sb.AppendLine("#pragma warning disable CS0612,CS0618");
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -35,6 +38,7 @@ namespace Generator.Equals
             sb.AppendLine(";");
             sb.AppendLine("}");
 
+            sb.AppendLine("#pragma warning restore CS0612,CS0618");
             sb.AppendLine("#nullable restore");
         }
 
@@ -43,6 +47,9 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
+            
+            // Obsolete with no comment, obsolete with comment
+            sb.AppendLine("#pragma warning disable CS0612,CS0618");
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -67,6 +74,7 @@ namespace Generator.Equals
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
 
+            sb.AppendLine("#pragma warning restore CS0612,CS0618");
             sb.AppendLine("#nullable restore");
         }
 

--- a/Generator.Equals/RecordEqualityGenerator.cs
+++ b/Generator.Equals/RecordEqualityGenerator.cs
@@ -45,9 +45,7 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
-            // Obsolete with no comment, obsolete with comment
-            sb.AppendLine("#pragma warning disable CS0612,CS0618");
+            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -72,7 +70,7 @@ namespace Generator.Equals
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
 
-            sb.AppendLine("#pragma warning restore CS0612,CS0618");
+            sb.AppendLine(RestoreObsoleteWarningsPragma);
             sb.AppendLine("#nullable restore");
         }
 

--- a/Generator.Equals/RecordEqualityGenerator.cs
+++ b/Generator.Equals/RecordEqualityGenerator.cs
@@ -10,9 +10,6 @@ namespace Generator.Equals
             var symbolName = symbol.ToFQF();
             var baseTypeName = symbol.BaseType?.ToFQF();
 
-            sb.AppendLine("#nullable enable");
-            sb.AppendLine(SuppressObsoleteWarningsPragma);
-
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
             sb.AppendLine(symbol.IsSealed
@@ -35,17 +32,11 @@ namespace Generator.Equals
 
             sb.AppendLine(";");
             sb.AppendLine("}");
-
-            sb.AppendLine(RestoreObsoleteWarningsPragma);
-            sb.AppendLine("#nullable restore");
         }
 
         static void BuildGetHashCode(ITypeSymbol symbol, AttributesMetadata attributesMetadata, StringBuilder sb)
         {
             var baseTypeName = symbol.BaseType?.ToFQF();
-
-            sb.AppendLine("#nullable enable");
-            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -69,18 +60,20 @@ namespace Generator.Equals
 
             sb.AppendLine("return hashCode.ToHashCode();");
             sb.AppendLine("}");
-
-            sb.AppendLine(RestoreObsoleteWarningsPragma);
-            sb.AppendLine("#nullable restore");
         }
 
         public static string Generate(ITypeSymbol symbol, AttributesMetadata attributesMetadata)
         {
             var code = ContainingTypesBuilder.Build(symbol, includeSelf: true, content: sb =>
             {
+                sb.AppendLine(EnableNullableContext);
+                sb.AppendLine(SuppressObsoleteWarningsPragma);
+                
                 BuildEquals(symbol, attributesMetadata, sb);
-
                 BuildGetHashCode(symbol, attributesMetadata, sb);
+
+                sb.AppendLine(RestoreObsoleteWarningsPragma);
+                sb.AppendLine(RestoreNullableContext);
             });
 
             return code;

--- a/Generator.Equals/RecordEqualityGenerator.cs
+++ b/Generator.Equals/RecordEqualityGenerator.cs
@@ -11,9 +11,7 @@ namespace Generator.Equals
             var baseTypeName = symbol.BaseType?.ToFQF();
 
             sb.AppendLine("#nullable enable");
-            
-            // Obsolete with no comment, obsolete with comment
-            sb.AppendLine("#pragma warning disable CS0612,CS0618");
+            sb.AppendLine(SuppressObsoleteWarningsPragma);
 
             sb.AppendLine(InheritDocComment);
             sb.AppendLine(GeneratedCodeAttributeDeclaration);
@@ -38,7 +36,7 @@ namespace Generator.Equals
             sb.AppendLine(";");
             sb.AppendLine("}");
 
-            sb.AppendLine("#pragma warning restore CS0612,CS0618");
+            sb.AppendLine(RestoreObsoleteWarningsPragma);
             sb.AppendLine("#nullable restore");
         }
 


### PR DESCRIPTION
Fixes #19

I don't know if there is a way to suppress `[Obsolete("comment", true)]`...so I left that for later.

I also considered wrapping _just_ the equality checks in a pragma, in case the generated code uses other obsolete code in the future. But that was more complicated and didn't seem worth it.