### PR TITLE
fix ArgumentException in EqualsGenerator caused by multiple partial classes/records

### DIFF
--- a/Generator.Equals.Tests/Classes/MultiplePartialsEquality.cs
+++ b/Generator.Equals.Tests/Classes/MultiplePartialsEquality.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+
+namespace Generator.Equals.Tests.Classes
+{
+    [TestFixture]
+    public partial class MultiplePartialsEquality : EqualityTestCase
+    {
+        [Equatable]
+        public partial class Data
+        {
+            [OrderedEquality] public string[]? Addresses { get; set; }
+        }
+        public partial class Data
+        {
+            public string FirstName { get; set; } = string.Empty;
+            public string LastName { get; set; } = string.Empty;
+        }
+        public partial class Data
+        {
+            [IgnoreEquality] public int Age { get; set; }
+        }
+
+        public override object Factory1() => new Data() { FirstName = "Dave", Age = 35, Addresses = new[] { "10 Downing St", "Bricklane" } };
+        public override object Factory2() => new Data() { FirstName = "Dave", Age = 42, Addresses = new[] { "10 Downing St", "Bricklane" } };
+        public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+        public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+    }
+}

--- a/Generator.Equals.Tests/Records/MultiplePartialsEquality.cs
+++ b/Generator.Equals.Tests/Records/MultiplePartialsEquality.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+
+namespace Generator.Equals.Tests.Records
+{
+    [TestFixture]
+    public partial class MultiplePartialsEquality : EqualityTestCase
+    {
+        [Equatable]
+        public partial record Data
+        {
+            [OrderedEquality] public string[]? Addresses { get; init; }
+        }
+        public partial record Data
+        {
+            public string FirstName { get; init; } = string.Empty;
+            public string LastName { get; init; } = string.Empty;
+        }
+        public partial record Data
+        {
+            [IgnoreEquality] public int Age { get; init; }
+        }
+
+        public override object Factory1() => new Data() { FirstName = "Dave", Age = 35, Addresses = new[] { "10 Downing St", "Bricklane" } };
+        public override object Factory2() => new Data() { FirstName = "Dave", Age = 42, Addresses = new[] { "10 Downing St", "Bricklane" } };
+        public override bool EqualsOperator(object value1, object value2) => (Data)value1 == (Data)value2;
+        public override bool NotEqualsOperator(object value1, object value2) => (Data)value1 != (Data)value2;
+    }
+}

--- a/Generator.Equals/EqualsGenerator.cs
+++ b/Generator.Equals/EqualsGenerator.cs
@@ -33,6 +33,8 @@ namespace Generator.Equals
                 context.Compilation.GetTypeByMetadataName("Generator.Equals.CustomEqualityAttribute")!
             );
 
+            var handledSymbols = new HashSet<string>();
+
             foreach (var node in s.CandidateSyntaxes)
             {
                 var model = context.Compilation.GetSemanticModel(node.SyntaxTree);
@@ -45,6 +47,13 @@ namespace Generator.Equals
                 if (equatableAttributeData == null)
                     continue;
 
+                var symbolDisplayString = symbol!.ToDisplayString();
+
+                if (handledSymbols.Contains(symbolDisplayString))
+                    continue;
+
+                handledSymbols.Add(symbolDisplayString);
+
                 var source = node switch
                 {
                     RecordDeclarationSyntax _ => RecordEqualityGenerator.Generate(symbol!, attributesMetadata),
@@ -52,7 +61,7 @@ namespace Generator.Equals
                     _ => throw new Exception("should not have gotten here.")
                 };
 
-                var fileName = $"{EscapeFileName(symbol!.ToDisplayString())}.Generator.Equals.g.cs"!;
+                var fileName = $"{EscapeFileName(symbolDisplayString)}.Generator.Equals.g.cs"!;
                 context.AddSource(fileName, source);
             }
 


### PR DESCRIPTION
When there are classes/records with multiple partial classes/records, `context.AddSource` in `EqualsGenerator` throws an `ArgumentException` with the message `The hintName '...Generator.Equals.g.cs' of the added source file must be unique within a generator`.

Each partial classes/records gets its own SyntaxNode entry, however the TypeSymbol is the same. This results in duplicate source generation.

With this PR `EqualsGenerator` checks if a source for a `TypeSymbol` was already created and then skips the candidate.