### PR TITLE
Support for record structs

### DIFF
--- a/Generator.Equals.Tests/RecordStructs/CustomEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/CustomEquality.Sample.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class CustomEquality
+    {
+        [Equatable]
+        public partial record struct Sample([property: CustomEquality(typeof(Comparer1))] string Name1, [property: CustomEquality(typeof(Comparer2), nameof(Comparer2.Instance))] string Name2, [property: CustomEquality(typeof(LengthEqualityComparer))] string Name3);
+
+        class Comparer1
+        {
+            public static readonly LengthEqualityComparer Default = new();
+        }
+
+        class Comparer2
+        {
+            public static readonly LengthEqualityComparer Instance = new();
+        }
+
+        class LengthEqualityComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string? x, string? y) => x?.Length == y?.Length;
+
+            public int GetHashCode(string obj) => obj.Length.GetHashCode();
+        }
+
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/CustomEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/CustomEquality.cs
@@ -1,0 +1,23 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class CustomEquality
+    {
+        
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("My String", "My String", "My String");
+            public override object Factory2() => new Sample("My ____ng", "My ____ng", "My ____ng");
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("My String", "My String", "My String");
+            public override object Factory2() => new Sample("My String ", "My String ", "My String ");
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.DistinctRecordStructs.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.DistinctRecordStructs.Sample.cs
@@ -1,0 +1,10 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class DistinctRecordStructs
+        {
+            public record Sample(string Name, int Age);
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.DistinctRecordStructs.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.DistinctRecordStructs.cs
@@ -1,0 +1,14 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class DistinctRecordStructs : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("John", 25);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithArray.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithArray.Sample.cs
@@ -1,0 +1,10 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class RecordStructsWithArray
+        {
+            public record Sample(string Name, int Age, string[] Addresses);
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithArray.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithArray.cs
@@ -1,0 +1,14 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class RecordStructsWithArray : EqualityTestCase
+        {
+            public override bool Expected => false;
+
+            public override object Factory1() => new Sample("Dave", 35, new[] {"10 Downing St"});
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithPrimitives.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithPrimitives.Sample.cs
@@ -1,0 +1,10 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class RecordStructsWithPrimitives
+        {
+            public record Sample(string Name, int Age);
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithPrimitives.cs
+++ b/Generator.Equals.Tests/RecordStructs/DefaultBehavior.RecordStructsWithPrimitives.cs
@@ -1,0 +1,12 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DefaultBehavior
+    {
+        public partial class RecordStructsWithPrimitives : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave", 35);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DictionaryEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/DictionaryEquality.Sample.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DictionaryEquality
+    {
+        [Equatable]
+        public partial record struct Sample
+        {
+            [UnorderedEquality] public Dictionary<string, int>? Properties { get; init; }
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/DictionaryEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/DictionaryEquality.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class DictionaryEquality
+    {
+        public class EqualsTests : EqualityTestCase
+        {
+            public override object Factory1()
+            {
+                var randomSort = new Random();
+
+                // This should generate objects with the same contents, but different orders, thus proving
+                // that dictionary equality is being used instead of the normal sequence equality.
+                return new Sample
+                {
+                    Properties = Enumerable
+                        .Range(1, 1000)
+                        .OrderBy(x => randomSort.NextDouble())
+                        .ToDictionary(x => x.ToString(), x => x)
+                };
+            }
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public partial class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+
+            public override object Factory1() => new Sample
+            {
+                Properties = Enumerable.Range(1, 1000).ToDictionary(x => x.ToString(), x => x)
+            };
+
+            public override object Factory2() => new Sample
+            {
+                Properties = Enumerable.Range(2, 999).ToDictionary(x => x.ToString(), x => x)
+            };
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ExplicitMode.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/ExplicitMode.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ExplicitMode
+    {
+        [Equatable(Explicit = true)]
+        public partial record struct Sample(string Name, [property: DefaultEquality]int Age);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ExplicitMode.cs
+++ b/Generator.Equals.Tests/RecordStructs/ExplicitMode.cs
@@ -1,0 +1,22 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ExplicitMode
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("John", 35);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("John", 40);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/GenericParameterEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/GenericParameterEquality.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class GenericParameterEquality
+    {
+        [Equatable]
+        public partial record struct Sample<TName, TAge>(TName Name, TAge Age);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/GenericParameterEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/GenericParameterEquality.cs
@@ -1,0 +1,30 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class GenericParameterEquality
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample<string, int>("Dave", 35);
+
+            public override bool EqualsOperator(object value1, object value2) =>
+                (Sample<string, int>) value1 == (Sample<string, int>) value2;
+
+            public override bool NotEqualsOperator(object value1, object value2) =>
+                (Sample<string, int>) value1 != (Sample<string, int>) value2;
+        }
+        
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample<string, int>("Dave", 35);
+            public override object Factory2() => new Sample<string, int>("Dave", 37);
+
+            public override bool EqualsOperator(object value1, object value2) =>
+                (Sample<string, int>) value1 == (Sample<string, int>) value2;
+
+            public override bool NotEqualsOperator(object value1, object value2) =>
+                (Sample<string, int>) value1 != (Sample<string, int>) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/IgnoreEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/IgnoreEquality.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class IgnoreEquality
+    {
+        [Equatable]
+        public partial record struct Sample(string Name, [property: IgnoreEquality] int Age);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/IgnoreEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/IgnoreEquality.cs
@@ -1,0 +1,22 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class IgnoreEquality
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("Dave", 85);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public  class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("John", 35);
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/NonSupportedMembers.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/NonSupportedMembers.Sample.cs
@@ -1,0 +1,13 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class NonSupportedMembers
+    {
+        [Equatable]
+        public partial record struct Sample(string Name)
+        {
+            public static int StaticProperty { get; }
+
+            public int this[int index] => index;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/NonSupportedMembers.cs
+++ b/Generator.Equals.Tests/RecordStructs/NonSupportedMembers.cs
@@ -1,0 +1,22 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class NonSupportedMembers 
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave");
+            public override object Factory2() => new Sample("Dave");
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public  class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave");
+            public override object Factory2() => new Sample("John");
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/NullableEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/NullableEquality.Sample.cs
@@ -1,0 +1,11 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class NullableEquality
+    {
+        [Equatable]
+        public partial record struct Sample
+        {
+            [OrderedEquality] public string[]? Addresses { get; init; }
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/NullableEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/NullableEquality.cs
@@ -1,0 +1,9 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class NullableEquality : EqualityTestCase
+    {
+        public override object Factory1() => new Sample();
+        public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+        public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ObsoleteMembers.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/ObsoleteMembers.Sample.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ObsoleteMembers
+    {
+        // DO NOT ADD [Obsolete] TO THIS MODEL. It would suppress the obsoletes on the properties by itself.
+        // This is why there is a separate ObsoleteRecord test.
+        [Equatable]
+        public partial record struct Sample(
+            [property: Obsolete] string NoComment
+            , [property: Obsolete("a comment")] string Comment
+            // Could not find a way to suppress this
+            // , [property: Obsolete("a comment", true)] string CommentAndError = ""
+            // No idea what to do with this
+            // , [property: Obsolete(DiagnosticId = "CUSTOM0001")] string OtherDiagnosticCode = ""
+        );
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ObsoleteMembers.cs
+++ b/Generator.Equals.Tests/RecordStructs/ObsoleteMembers.cs
@@ -1,0 +1,22 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ObsoleteMembers
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave", "Smith");
+            public override object Factory2() => new Sample("Dave", "Smith");
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave", "West");
+            public override object Factory2() => new Sample("John", "Smith");
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ObsoleteRecord.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/ObsoleteRecord.Sample.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ObsoleteRecord
+    {
+        [Equatable]
+        [Obsolete("Make sure the obsolete on the object model does not add warnings")]
+        public partial record struct Sample(string Name);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ObsoleteRecord.cs
+++ b/Generator.Equals.Tests/RecordStructs/ObsoleteRecord.cs
@@ -1,0 +1,24 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ObsoleteRecord
+    {
+#pragma warning disable CS0618
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave");
+            public override object Factory2() => new Sample("Dave");
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave");
+            public override object Factory2() => new Sample("John");
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+#pragma warning restore CS0618
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/OrderedEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/OrderedEquality.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class OrderedEquality
+    {
+        [Equatable]
+        public partial record struct Sample([property: OrderedEquality] string[] Addresses);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/OrderedEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/OrderedEquality.cs
@@ -1,0 +1,21 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class OrderedEquality
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample(new[] {"10 Downing St"});
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample(new[] {"10 Downing St"});
+            public override object Factory2() => new Sample(new[] {"Bricklane"});
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/PrimitiveEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/PrimitiveEquality.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class PrimitiveEquality
+    {
+        [Equatable]
+        public partial record struct Sample(string Name, int Age);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/PrimitiveEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/PrimitiveEquality.cs
@@ -1,0 +1,22 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class PrimitiveEquality
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample("Dave", 35);
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+
+        public class NotEqualsTest : EqualityTestCase
+        {
+
+            public override bool Expected => false;
+            public override object Factory1() => new Sample("Dave", 35);
+            public override object Factory2() => new Sample("Joe", 77);
+            public override bool EqualsOperator(object value1, object value2) => (Sample)value1 == (Sample)value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample)value1 != (Sample)value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ReferenceEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/ReferenceEquality.Sample.cs
@@ -1,0 +1,8 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ReferenceEquality
+    {
+        [Equatable]
+        public partial record struct Sample([property: ReferenceEquality] string Name);
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/ReferenceEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/ReferenceEquality.cs
@@ -1,0 +1,21 @@
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class ReferenceEquality
+    {
+        public class EqualsTest : EqualityTestCase
+        {
+            public override object Factory1() => new Sample(string.Intern($"Dave{35}"));
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+            public override object Factory1() => new Sample($"Dave{35}");
+            public override object Factory2() => new Sample($"Dave{35}");
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/SetEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/SetEquality.Sample.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class SetEquality
+    {
+        [Equatable]
+        public partial record struct Sample
+        {
+            [SetEquality] public List<int>? Properties { get; set; }
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/SetEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/SetEquality.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using FluentAssertions;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class SetEquality
+    {
+        public class EqualsTests : EqualityTestCase
+        {
+            public override object Factory1()
+            {
+                return new Sample
+                {
+                    Properties = new List<int> { 1, 2, 3, 4, 5, 5, 4, 3, 2, 1}
+                };
+            }
+            
+            public override object Factory2()
+            {
+                return new Sample
+                {
+                    Properties = new List<int> { 1, 5, 2, 4, 3 }
+                };
+            }
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+
+            public override object Factory1() => new Sample
+            {
+                Properties = new List<int> { 1, 2, 3, 4, 5 }
+            };
+
+            public override object Factory2() => new Sample
+            {
+                Properties = new List<int> { 1, 2, 3, 4 }
+            };
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+
+            public override void TestHashCode()
+            {
+                var value1 = Factory1();
+                var value2 = Factory2();
+                var result = value1.GetHashCode() == value2.GetHashCode();
+
+                result.Should().BeTrue();
+            }
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/UnorderedEquality.Sample.cs
+++ b/Generator.Equals.Tests/RecordStructs/UnorderedEquality.Sample.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class UnorderedEquality
+    {
+        [Equatable]
+        public partial record struct Sample
+        {
+            [UnorderedEquality] public List<int>? Properties { get; init; }
+        }
+    }
+}

--- a/Generator.Equals.Tests/RecordStructs/UnorderedEquality.cs
+++ b/Generator.Equals.Tests/RecordStructs/UnorderedEquality.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+
+namespace Generator.Equals.Tests.RecordStructs
+{
+    public partial class UnorderedEquality
+    {
+        public class EqualsTests : EqualityTestCase
+        {
+            public override object Factory1()
+            {
+                var randomSort = new Random();
+
+                // This should generate objects with the same contents, but different orders, thus proving
+                // that dictionary equality is being used instead of the normal sequence equality.
+                return new Sample
+                {
+                    Properties = Enumerable
+                        .Range(1, 1000)
+                        .OrderBy(_ => randomSort.NextDouble())
+                        .ToList()
+                };
+            }
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+        
+        public class NotEqualsTest : EqualityTestCase
+        {
+            public override bool Expected => false;
+
+            public override object Factory1() => new Sample
+            {
+                Properties = Enumerable.Range(1, 1000).ToList()
+            };
+
+            public override object Factory2() => new Sample
+            {
+                Properties = Enumerable.Range(1, 1001).ToList()
+            };
+
+            public override bool EqualsOperator(object value1, object value2) => (Sample) value1 == (Sample) value2;
+            public override bool NotEqualsOperator(object value1, object value2) => (Sample) value1 != (Sample) value2;
+        }
+    }
+}

--- a/Generator.Equals/ClassEqualityGenerator.cs
+++ b/Generator.Equals/ClassEqualityGenerator.cs
@@ -51,7 +51,7 @@ namespace Generator.Equals
 
             foreach (var property in symbol.GetProperties())
             {
-                BuildPropertyEquality(attributesMetadata, sb, level, property, explicitMode);
+                BuildPropertyEquality(attributesMetadata, sb, level, property, explicitMode,  true);
             }
 
             sb.AppendLine(level, ";");
@@ -84,7 +84,7 @@ namespace Generator.Equals
 
             foreach (var property in symbol.GetProperties())
             {
-                BuildPropertyHashCode(property, attributesMetadata, sb, level, explicitMode);
+                BuildPropertyHashCode(property, attributesMetadata, sb, level, explicitMode, true);
             }
 
             sb.AppendLine(level);

--- a/Generator.Equals/ContainingTypesBuilder.cs
+++ b/Generator.Equals/ContainingTypesBuilder.cs
@@ -24,7 +24,7 @@ namespace Generator.Equals
         {
             if (includeSelf && symbol is INamespaceOrTypeSymbol self)
                 yield return self;
-            
+
             while (true)
             {
                 symbol = symbol.ContainingSymbol;
@@ -61,13 +61,23 @@ namespace Generator.Equals
                 }
                 else
                 {
-                    var keyword = s.DeclaringSyntaxReferences
+                    var typeDeclarationSyntax = s.DeclaringSyntaxReferences
                         .Select(x => x.GetSyntax())
                         .OfType<TypeDeclarationSyntax>()
-                        .First()
-                        .Keyword
-                        .ValueText;
-                 
+                        .First();
+
+                    string keyword;
+                    if (typeDeclarationSyntax.RawKind == 9068) //RecordStructDeclaration - this appears to be the only way to get it
+                    {
+                        keyword = "record struct";
+                    }
+                    else
+                    {
+                        keyword = typeDeclarationSyntax
+                            .Keyword
+                            .ValueText;
+                    }
+
                     var typeName = s.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                     sb.AppendLine(level, $"partial {keyword} {typeName}");
                     sb.AppendOpenBracket(ref level);

--- a/Generator.Equals/EqualityGeneratorBase.cs
+++ b/Generator.Equals/EqualityGeneratorBase.cs
@@ -33,8 +33,9 @@ namespace Generator.Equals
         protected const string InheritDocComment = "/// <inheritdoc/>";
 
         public static void BuildPropertyEquality(AttributesMetadata attributesMetadata, StringBuilder sb, int level,
-            IPropertySymbol property, bool explicitMode)
+            IPropertySymbol property, bool explicitMode, bool useNullForgivingOperators)
         {
+            var nf = useNullForgivingOperators ? "!" : "";
             if (property.HasAttribute(attributesMetadata.IgnoreEquality))
                 return;
 
@@ -49,13 +50,13 @@ namespace Generator.Equals
                 if (types != null)
                 {
                     sb.AppendLine(level,
-                        $"&& global::Generator.Equals.DictionaryEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                        $"&& global::Generator.Equals.DictionaryEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
                 }
                 else
                 {
                     types = property.GetIEnumerableTypeArguments()!;
                     sb.AppendLine(level,
-                        $"&& global::Generator.Equals.UnorderedEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                        $"&& global::Generator.Equals.UnorderedEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
                 }
             }
             else if (property.HasAttribute(attributesMetadata.OrderedEquality))
@@ -63,19 +64,19 @@ namespace Generator.Equals
                 var types = property.GetIEnumerableTypeArguments()!;
 
                 sb.AppendLine(level,
-                    $"&& global::Generator.Equals.OrderedEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                    $"&& global::Generator.Equals.OrderedEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
             }
             else if (property.HasAttribute(attributesMetadata.ReferenceEquality))
             {
                 sb.AppendLine(level,
-                    $"&& global::Generator.Equals.ReferenceEqualityComparer<{typeName}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                    $"&& global::Generator.Equals.ReferenceEqualityComparer<{typeName}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
             }
             else if (property.HasAttribute(attributesMetadata.SetEquality))
             {
                 var types = property.GetIEnumerableTypeArguments()!;
 
                 sb.AppendLine(level,
-                    $"&& global::Generator.Equals.SetEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                    $"&& global::Generator.Equals.SetEqualityComparer<{string.Join(", ", types.Value)}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
             }
             else if (property.HasAttribute(attributesMetadata.CustomEquality))
             {
@@ -86,12 +87,12 @@ namespace Generator.Equals
                 if (comparerType.GetMembers().Any(x => x.Name == comparerMemberName && x.IsStatic) || comparerType.GetProperties().Any(x => x.Name == comparerMemberName && x.IsStatic))
                 {
                     sb.AppendLine(level,
-                        $"&& {comparerType.ToFQF()}.{comparerMemberName}.Equals({propertyName}!, other.{propertyName}!)");
+                        $"&& {comparerType.ToFQF()}.{comparerMemberName}.Equals({propertyName}{nf}, other.{propertyName}{nf})");
                 }
                 else
                 {
                     sb.AppendLine(level,
-                        $"&& new {comparerType.ToFQF()}().Equals({propertyName}!, other.{propertyName}!)");
+                        $"&& new {comparerType.ToFQF()}().Equals({propertyName}{nf}, other.{propertyName}{nf})");
                 }
             }
             else if (
@@ -99,7 +100,7 @@ namespace Generator.Equals
                 property.HasAttribute(attributesMetadata.DefaultEquality))
             {
                 sb.AppendLine(level,
-                    $"&& global::System.Collections.Generic.EqualityComparer<{typeName}>.Default.Equals({propertyName}!, other.{propertyName}!)");
+                    $"&& global::System.Collections.Generic.EqualityComparer<{typeName}>.Default.Equals({propertyName}{nf}, other.{propertyName}{nf})");
             }
         }
 
@@ -108,8 +109,9 @@ namespace Generator.Equals
             AttributesMetadata attributesMetadata,
             StringBuilder sb,
             int level,
-            bool explicitMode)
+            bool explicitMode, bool useNullForgivingOperators)
         {
+            var nf = useNullForgivingOperators ? "!" : "";
             if (property.HasAttribute(attributesMetadata.IgnoreEquality))
                 return;
 
@@ -128,7 +130,7 @@ namespace Generator.Equals
 
             sb.AppendLine(level, $"hashCode.Add(");
             level++;
-            sb.AppendLine(level, $"this.{propertyName}!,");
+            sb.AppendLine(level, $"this.{propertyName}{nf},");
             sb.AppendMargin(level);
 
             if (property.HasAttribute(attributesMetadata.UnorderedEquality))

--- a/Generator.Equals/EqualsGenerator.cs
+++ b/Generator.Equals/EqualsGenerator.cs
@@ -66,8 +66,8 @@ namespace Generator.Equals
                     .Value.Value is true;
                 var source = node switch
                 {
-                    RecordDeclarationSyntax _ => RecordEqualityGenerator.Generate(symbol!, attributesMetadata,
-                        explicitMode, ignoreInheritedMembers),
+                    RecordDeclarationSyntax _ when node.RawKind == 9068 => RecordStructEqualityGenerator.Generate(symbol!, attributesMetadata, explicitMode),
+                    RecordDeclarationSyntax _ => RecordEqualityGenerator.Generate(symbol!, attributesMetadata, explicitMode, ignoreInheritedMembers),
                     ClassDeclarationSyntax _ => ClassEqualityGenerator.Generate(symbol!, attributesMetadata,
                         explicitMode, ignoreInheritedMembers),
                     _ => throw new Exception("should not have gotten here.")


### PR DESCRIPTION
Closes #32 

This adds support for record structs. It works by testing `typeDeclarationSyntax.RawKind == 9068` which is not particularly elegant. Later versions of Roslyn might have more ergonomic syntax but I understand if you want to avoid updating.  

I've made copies of all the relevant Tests and updated them to use record structs.  

Unfortunately I can't seem to get the snapshot tests to work. They seem to generate lots of diagnostic errors which don't seem to make sense. I wonder if you have any insight into what the problem is?