### PR TITLE
fix: ignore GE001 diagnostic on collections that implement IEquatable<T>

### DIFF
--- a/Generator.Equals.Tests/Analyzers/GE001CollectionMissingAttributeTests.cs
+++ b/Generator.Equals.Tests/Analyzers/GE001CollectionMissingAttributeTests.cs
@@ -278,4 +278,33 @@ public sealed class GE001CollectionMissingAttributeTests : AnalyzerTestBase<Equa
         // [DefaultEquality] + [OrderedEquality] satisfies the requirement
         await VerifyNoDiagnosticAsync(source);
     }
+
+    [Fact]
+    public async Task CustomCollectionProperty_WithEquatable_NoDiagnostic()
+    {
+        const string source = """
+            using System.Collections;
+            using System.Collections.Generic;
+            using Generator.Equals;
+
+            [Equatable]
+            public partial class Sample
+            {
+                public MyCollection<int> Items { get; set; }
+            }
+            
+            [Equatable]
+            public partial class MyCollection<T> : IEnumerable<T>
+            {
+                [OrderedEquality]
+                private readonly List<T> _list = new();
+                public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                public void Add(T item) => _list.Add(item);
+            }
+            """;
+
+        // [Equatable] implementation on custom collection
+        await VerifyNoDiagnosticAsync(source);
+    }
 }

--- a/Generator.Equals/Analyzers/EquatableAnalyzer.cs
+++ b/Generator.Equals/Analyzers/EquatableAnalyzer.cs
@@ -168,7 +168,7 @@ public class EquatableAnalyzer : DiagnosticAnalyzer
             CollectionEqualityAttributes.Contains(x.Metadata));
 
         // GE001: Collection without collection equality attribute
-        if (memberType.IsCollection() && !hasCollectionAttribute)
+        if (memberType.IsCollection() && !hasCollectionAttribute && !memberType.HasProperEquality())
         {
             var location = GetMemberTypeLocation(member) ?? member.Locations.FirstOrDefault() ?? Location.None;
             context.ReportDiagnostic(Diagnostic.Create(


### PR DESCRIPTION
Hey, I've been a fan of your package for a long time now! It is such a breeze to use.
I've also been peeking at the source code for my own generators which is really helpful. Thanks a lot!

---

I have a custom collection that I use lots of times in my projects and it already implements `IEquatable<T>`. The analyzer does not know about this though and flags all properties of that type with `GE001`.
This tiny patch should remove the warning when a collection type implements the interface.