### PR TITLE
fix: emit XML doc comments on generated EqualityComparer (#76)

### DIFF
--- a/Generator.Equals.Tests/Infrastructure/XmlDocumentationTests.cs
+++ b/Generator.Equals.Tests/Infrastructure/XmlDocumentationTests.cs
@@ -1,0 +1,108 @@
+extern alias GeneratorEquals;
+
+using System.Collections.Immutable;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Generator.Equals.Tests.Infrastructure;
+
+/// <summary>
+/// Guards against CS1591 ("missing XML comment for publicly visible type or member") being raised
+/// on the generated code when the consuming project enables <c>GenerateDocumentationFile</c>. See issue #76.
+/// </summary>
+public class XmlDocumentationTests
+{
+    const string MissingXmlCommentWarning = "CS1591";
+
+    static readonly MetadataReference RuntimeReference = MetadataReference.CreateFromFile(
+        typeof(Generator.Equals.EquatableAttribute).Assembly.Location);
+
+    /// <summary>
+    /// Every public member emitted by the generator must carry an XML doc comment, for all supported type kinds
+    /// and for both root and derived types (derived types emit a slightly different comparer declaration).
+    /// </summary>
+    const string Source = """
+        using Generator.Equals;
+
+        namespace Sample;
+
+        /// <summary>A class.</summary>
+        [Equatable]
+        public partial class Root
+        {
+            /// <summary>A property.</summary>
+            public string? Name { get; set; }
+        }
+
+        /// <summary>A derived class.</summary>
+        [Equatable]
+        public partial class Derived : Root
+        {
+            /// <summary>A property.</summary>
+            public int Age { get; set; }
+        }
+
+        /// <summary>A record.</summary>
+        [Equatable]
+        public partial record RootRecord
+        {
+            /// <summary>A property.</summary>
+            public string? Name { get; set; }
+        }
+
+        /// <summary>A derived record.</summary>
+        [Equatable]
+        public partial record DerivedRecord : RootRecord
+        {
+            /// <summary>A property.</summary>
+            public int Age { get; set; }
+        }
+
+        /// <summary>A struct.</summary>
+        [Equatable]
+        public partial struct SampleStruct
+        {
+            /// <summary>A property.</summary>
+            public int Age { get; set; }
+        }
+
+        /// <summary>A record struct.</summary>
+        [Equatable]
+        public partial record struct SampleRecordStruct
+        {
+            /// <summary>A property.</summary>
+            public int Age { get; set; }
+        }
+        """;
+
+    [Fact]
+    public async Task GeneratedCodeHasNoMissingXmlCommentWarnings()
+    {
+        // DocumentationMode.Diagnose is what <GenerateDocumentationFile>true</GenerateDocumentationFile> turns on.
+        var parseOptions = new CSharpParseOptions(LanguageVersion.CSharp10, DocumentationMode.Diagnose);
+
+        var references = await ReferenceAssemblies.Net.Net60.ResolveAsync(null, TestContext.Current.CancellationToken);
+
+        var compilation = (Compilation)CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(Source, parseOptions, cancellationToken: TestContext.Current.CancellationToken)],
+            references: references.Add(RuntimeReference),
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        CSharpGeneratorDriver
+            .Create([new GeneratorEquals::Generator.Equals.EqualsGenerator().AsSourceGenerator()], parseOptions: parseOptions)
+            .RunGeneratorsAndUpdateCompilation(compilation, out var updated, out _, TestContext.Current.CancellationToken);
+
+        var warnings = updated
+            .GetDiagnostics(TestContext.Current.CancellationToken)
+            .Where(d => d.Id == MissingXmlCommentWarning)
+            .Select(d => $"{d.Location.GetLineSpan()}: {d.GetMessage()}")
+            .ToImmutableArray();
+
+        warnings.Should().BeEmpty();
+    }
+}

--- a/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.BaseEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.BaseEqualityManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.BaseEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.BaseEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.BaseEqualityPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.BaseEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.BaseEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.BaseEqualityManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.BaseEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.BaseEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.BaseEqualityPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.BaseEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Classes.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Classes.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualityManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualityPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DeepEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualityManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualityPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DeepEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DeepEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Classes.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/EnumerableEqualityTests.Net60#global__Generator.Equals.Tests.Classes.EnumerableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/EnumerableEqualityTests.Net60#global__Generator.Equals.Tests.Classes.EnumerableEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.EnumerableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/EnumerableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.EnumerableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/EnumerableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.EnumerableEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.EnumerableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Classes.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Classes.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Classes.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Classes.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Classes.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Classes.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.Net60#global__Generator.Equals.Tests.Classes.GapChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.Net60#global__Generator.Equals.Tests.Classes.GapChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GapChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.Net60#global__Generator.Equals.Tests.Classes.GapGrandParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.Net60#global__Generator.Equals.Tests.Classes.GapGrandParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GapGrandParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.NetFramework48#global__Generator.Equals.Tests.Classes.GapChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.NetFramework48#global__Generator.Equals.Tests.Classes.GapChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GapChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.NetFramework48#global__Generator.Equals.Tests.Classes.GapGrandParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GapInheritanceTests.NetFramework48#global__Generator.Equals.Tests.Classes.GapGrandParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GapGrandParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Classes.GenericSample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Classes.GenericSample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GenericSample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.GenericSample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.GenericSample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.GenericSample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Classes.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Classes.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/IgnoreInheritedMembersTests.Net60#global__Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/IgnoreInheritedMembersTests.Net60#global__Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/IgnoreInheritedMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/IgnoreInheritedMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.IgnoreInheritedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesChildWithOwnAttribute>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedEqualityAttributesParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedFromNonEquatableTests.Net60#global__Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedFromNonEquatableTests.Net60#global__Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedFromNonEquatableTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedFromNonEquatableTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedFromNonEquatableChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
@@ -59,9 +59,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
@@ -59,9 +59,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedOverrideSkippedChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedOverrideSkippedParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedPropertiesNoEquatableTests.Net60#global__Generator.Equals.Tests.Classes.InheritedPropertiesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedPropertiesNoEquatableTests.Net60#global__Generator.Equals.Tests.Classes.InheritedPropertiesChild.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedPropertiesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/InheritedPropertiesNoEquatableTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedPropertiesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/InheritedPropertiesNoEquatableTests.NetFramework48#global__Generator.Equals.Tests.Classes.InheritedPropertiesChild.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.InheritedPropertiesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Classes.MultiplePartialsSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Classes.MultiplePartialsSample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.MultiplePartialsSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.MultiplePartialsSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.MultiplePartialsSample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.MultiplePartialsSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Classes.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Classes.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Classes.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Classes.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ObsoleteClassTests.Net60#global__Generator.Equals.Tests.Classes.ObsoleteClassSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ObsoleteClassTests.Net60#global__Generator.Equals.Tests.Classes.ObsoleteClassSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ObsoleteClassSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ObsoleteClassTests.NetFramework48#global__Generator.Equals.Tests.Classes.ObsoleteClassSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ObsoleteClassTests.NetFramework48#global__Generator.Equals.Tests.Classes.ObsoleteClassSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ObsoleteClassSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Classes.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Classes.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Classes.OverridingEqualsPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Classes.OverridingEqualsPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OverridingEqualsPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Classes.OverridingEqualsPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Classes.OverridingEqualsPerson.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OverridingEqualsPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.OverridingEqualsSeniorManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PolymorphicAnimal.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PolymorphicAnimal.Generator.Equals.g.verified.cs
@@ -59,9 +59,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PolymorphicAnimal>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PolymorphicDog.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PolymorphicDog.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PolymorphicDog>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PolymorphicAnimal.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PolymorphicAnimal.Generator.Equals.g.verified.cs
@@ -59,9 +59,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PolymorphicAnimal>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PolymorphicDog.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PolymorphicBaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PolymorphicDog.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PolymorphicDog>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -60,9 +60,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Classes.PrimaryCtorSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Classes.PrimaryCtorSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimaryCtorSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimaryCtorSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimaryCtorSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimaryCtorSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimaryCtorSampleWithProperties>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Classes.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -69,9 +69,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Classes.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Classes.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Classes.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Classes.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Classes.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -74,9 +74,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SealedClassTests.Net60#global__Generator.Equals.Tests.Classes.SealedClassSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SealedClassTests.Net60#global__Generator.Equals.Tests.Classes.SealedClassSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SealedClassSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SealedClassTests.NetFramework48#global__Generator.Equals.Tests.Classes.SealedClassSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SealedClassTests.NetFramework48#global__Generator.Equals.Tests.Classes.SealedClassSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SealedClassSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.Net60#global__Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.Net60#global__Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.Net60#global__Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.Net60#global__Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.StringEqualityCaseInsensitiveSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.StringEqualityCaseSensitiveSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Classes/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -64,9 +64,15 @@ namespace Generator.Equals.Tests.Classes
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Classes.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/CustomEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/CustomEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -41,9 +41,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -41,9 +41,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ExplicitModeTests.Net60#global__Generator.Equals.Tests.RecordStructs.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ExplicitModeTests.Net60#global__Generator.Equals.Tests.RecordStructs.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/FieldEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/FieldEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/NullableEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/NullableEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteRecordTests.Net60#global__Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteRecordTests.Net60#global__Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteRecordTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ObsoleteRecordTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ObsoleteRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -27,9 +27,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -36,9 +36,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/RequiredMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/RequiredMembersTests.Net60#global__Generator.Equals.Tests.RecordStructs.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -41,9 +41,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -41,9 +41,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/RecordStructs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -31,9 +31,15 @@ namespace Generator.Equals.Tests.RecordStructs
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.RecordStructs.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Records.BaseEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Records.BaseEqualityManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.BaseEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Records.BaseEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.Net60#global__Generator.Equals.Tests.Records.BaseEqualityPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.BaseEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.BaseEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.BaseEqualityManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.BaseEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.BaseEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/BaseEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.BaseEqualityPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.BaseEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Records.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Records.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualityManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualityPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.Net60#global__Generator.Equals.Tests.Records.DeepEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualityManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualityManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualityManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualityPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualityPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualityPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DeepEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DeepEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DeepEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Records.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Records.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Records.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Records.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Records.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Records.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Records.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Records.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Records.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Records.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Records.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Records.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/IgnoreInheritedMembersTests.Net60#global__Generator.Equals.Tests.Records.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/IgnoreInheritedMembersTests.Net60#global__Generator.Equals.Tests.Records.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.IgnoreInheritedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/IgnoreInheritedMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/IgnoreInheritedMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.IgnoreInheritedMembersSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.IgnoreInheritedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.Net60#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChild.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesChildWithOwnAttribute>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedEqualityAttributesTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedEqualityAttributesParent.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedEqualityAttributesParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedFromNonEquatableTests.Net60#global__Generator.Equals.Tests.Records.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedFromNonEquatableTests.Net60#global__Generator.Equals.Tests.Records.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedFromNonEquatableChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedFromNonEquatableTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedFromNonEquatableTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedFromNonEquatableChild.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedFromNonEquatableChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
@@ -28,9 +28,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedOverrideSkippedChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.Net60#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedOverrideSkippedParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedChild.Generator.Equals.g.verified.cs
@@ -28,9 +28,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedOverrideSkippedChild>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/InheritedOverrideSkippedTests.NetFramework48#global__Generator.Equals.Tests.Records.InheritedOverrideSkippedParent.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.InheritedOverrideSkippedParent>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Records.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Records.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.MultiplePartialsEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.MultiplePartialsEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Records.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Records.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Records.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Records.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Records.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Records.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ObsoleteRecordTests.Net60#global__Generator.Equals.Tests.Records.ObsoleteRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ObsoleteRecordTests.Net60#global__Generator.Equals.Tests.Records.ObsoleteRecordSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ObsoleteRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ObsoleteRecordTests.NetFramework48#global__Generator.Equals.Tests.Records.ObsoleteRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ObsoleteRecordTests.NetFramework48#global__Generator.Equals.Tests.Records.ObsoleteRecordSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ObsoleteRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Records.OverridingEqualsPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Records.OverridingEqualsPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OverridingEqualsPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Records.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.Net60#global__Generator.Equals.Tests.Records.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OverridingEqualsSeniorManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Records.OverridingEqualsPerson.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Records.OverridingEqualsPerson.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OverridingEqualsPerson>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Records.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/OverridingEqualsTests.NetFramework48#global__Generator.Equals.Tests.Records.OverridingEqualsSeniorManager.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public new sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.OverridingEqualsSeniorManager>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -29,9 +29,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Records.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -38,9 +38,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Records.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Records.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Records.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Records.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Records.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SealedRecordTests.Net60#global__Generator.Equals.Tests.Records.SealedRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SealedRecordTests.Net60#global__Generator.Equals.Tests.Records.SealedRecordSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SealedRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SealedRecordTests.NetFramework48#global__Generator.Equals.Tests.Records.SealedRecordSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SealedRecordTests.NetFramework48#global__Generator.Equals.Tests.Records.SealedRecordSample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SealedRecordSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityTests.Net60#global__Generator.Equals.Tests.Records.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityTests.Net60#global__Generator.Equals.Tests.Records.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.Net60#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.Net60#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.Net60#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.Net60#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Records/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -33,9 +33,15 @@ namespace Generator.Equals.Tests.Records
             return hashCode.ToHashCode();
         }
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Records.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Structs.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/CustomEqualityTests.Net60#global__Generator.Equals.Tests.Structs.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.CustomEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/CustomEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.CustomEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.CustomEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Structs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/DictionaryEqualityTests.Net60#global__Generator.Equals.Tests.Structs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/DictionaryEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.DictionaryEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.DictionaryEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Structs.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ExplicitModeTests.Net60#global__Generator.Equals.Tests.Structs.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Structs.ExplicitModeSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ExplicitModeTests.NetFramework48#global__Generator.Equals.Tests.Structs.ExplicitModeSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ExplicitModeSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Structs.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/FieldEqualityTests.Net60#global__Generator.Equals.Tests.Structs.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.FieldEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/FieldEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.FieldEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.FieldEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Structs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/GenericParameterEqualityTests.Net60#global__Generator.Equals.Tests.Structs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/GenericParameterEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.GenericParameterEqualitySample_TName_ TAge_.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.GenericParameterEqualitySample<TName, TAge>>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Structs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/IgnoreEqualityTests.Net60#global__Generator.Equals.Tests.Structs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/IgnoreEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.IgnoreEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.IgnoreEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/MultiplePartialsEqualityTests.Net60#global__Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/MultiplePartialsEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.MultiplePartialsEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Structs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/NonSupportedMembersTests.Net60#global__Generator.Equals.Tests.Structs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/NonSupportedMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.NonSupportedMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.NonSupportedMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Structs.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/NullableEqualityTests.Net60#global__Generator.Equals.Tests.Structs.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.NullableEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/NullableEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.NullableEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.NullableEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Structs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ObsoleteMembersTests.Net60#global__Generator.Equals.Tests.Structs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ObsoleteMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.ObsoleteMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ObsoleteMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ObsoleteStructTests.Net60#global__Generator.Equals.Tests.Structs.ObsoleteStructSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ObsoleteStructTests.Net60#global__Generator.Equals.Tests.Structs.ObsoleteStructSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ObsoleteStructSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ObsoleteStructTests.NetFramework48#global__Generator.Equals.Tests.Structs.ObsoleteStructSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ObsoleteStructTests.NetFramework48#global__Generator.Equals.Tests.Structs.ObsoleteStructSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ObsoleteStructSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/OrderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.OrderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityDecimalSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityFloatSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityIntSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityNullableDoubleSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrecisionEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrecisionEqualityNullableIntSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Structs.PrimaryCtorSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrimaryConstructorTests.Net60#global__Generator.Equals.Tests.Structs.PrimaryCtorSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrimaryCtorSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrimaryCtorSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrimaryConstructorTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrimaryCtorSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrimaryCtorSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrimitiveEqualityTests.Net60#global__Generator.Equals.Tests.Structs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/PrimitiveEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.PrimitiveEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.PrimitiveEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Structs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ReferenceEqualityTests.Net60#global__Generator.Equals.Tests.Structs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/ReferenceEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.ReferenceEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.ReferenceEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Structs.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/RequiredMembersTests.Net60#global__Generator.Equals.Tests.Structs.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.RequiredMembersSample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/RequiredMembersTests.NetFramework48#global__Generator.Equals.Tests.Structs.RequiredMembersSample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.RequiredMembersSample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/SetEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.SetEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.Net60#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.Net60#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.Net60#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.Net60#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.StringEqualitySampleCaseInsensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/StringEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.StringEqualitySampleCaseSensitive>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualitySample.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualitySample>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.Net60#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithCustomComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithLengthComparer>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
+++ b/Generator.Equals.Tests/Snapshots/Structs/UnorderedEqualityWithComparerTests.NetFramework48#global__Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison.Generator.Equals.g.verified.cs
@@ -43,9 +43,15 @@ namespace Generator.Equals.Tests.Structs
         public override int GetHashCode() =>
             EqualityComparer.Default.GetHashCode(this);
         
+        /// <summary>
+        /// An equality comparer for the enclosing type that uses the generated equality semantics.
+        /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Generator.Equals", "1.0.0.0")]
         public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<global::Generator.Equals.Tests.Structs.UnorderedEqualityWithComparerSampleWithStringComparison>
         {
+            /// <summary>
+            /// Gets the default instance of the comparer.
+            /// </summary>
             public static EqualityComparer Default { get; } = new EqualityComparer();
             
             /// <inheritdoc/>

--- a/Generator.Equals/EqualityGeneratorBase.cs
+++ b/Generator.Equals/EqualityGeneratorBase.cs
@@ -39,6 +39,16 @@ namespace Generator.Equals
 
         protected const string InheritDocComment = "/// <inheritdoc/>";
 
+        protected static readonly string[] EqualityComparerCodeComment = @"
+/// <summary>
+/// An equality comparer for the enclosing type that uses the generated equality semantics.
+/// </summary>".ToLines();
+
+        protected static readonly string[] EqualityComparerDefaultCodeComment = @"
+/// <summary>
+/// Gets the default instance of the comparer.
+/// </summary>".ToLines();
+
         static string GetCollectionComparerExpression(
             string comparerClassName,
             string elementTypeName,

--- a/Generator.Equals/Generators/ClassEqualityGenerator.cs
+++ b/Generator.Equals/Generators/ClassEqualityGenerator.cs
@@ -127,11 +127,13 @@ namespace Generator.Equals.Generators
             var newKeyword = model.BaseHasEquatable ? "new " : "";
 
             writer.WriteLine();
+            writer.WriteLines(EqualityComparerCodeComment);
             writer.WriteLine(GeneratedCodeAttributeDeclaration);
             writer.WriteLine($"public {newKeyword}sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<{symbolName}>");
             writer.AppendOpenBracket();
 
             // Default instance
+            writer.WriteLines(EqualityComparerDefaultCodeComment);
             writer.WriteLine("public static EqualityComparer Default { get; } = new EqualityComparer();");
             writer.WriteLine();
 

--- a/Generator.Equals/Generators/RecordEqualityGenerator.cs
+++ b/Generator.Equals/Generators/RecordEqualityGenerator.cs
@@ -94,11 +94,13 @@ namespace Generator.Equals.Generators
             var newKeyword = model.BaseHasEquatable ? "new " : "";
 
             writer.WriteLine();
+            writer.WriteLines(EqualityComparerCodeComment);
             writer.WriteLine(GeneratedCodeAttributeDeclaration);
             writer.WriteLine($"public {newKeyword}sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<{symbolName}>");
             writer.AppendOpenBracket();
 
             // Default instance
+            writer.WriteLines(EqualityComparerDefaultCodeComment);
             writer.WriteLine("public static EqualityComparer Default { get; } = new EqualityComparer();");
             writer.WriteLine();
 

--- a/Generator.Equals/Generators/RecordStructEqualityGenerator.cs
+++ b/Generator.Equals/Generators/RecordStructEqualityGenerator.cs
@@ -53,11 +53,13 @@ namespace Generator.Equals.Generators
             var symbolName = model.Fullname;
 
             writer.WriteLine();
+            writer.WriteLines(EqualityComparerCodeComment);
             writer.WriteLine(GeneratedCodeAttributeDeclaration);
             writer.WriteLine($"public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<{symbolName}>");
             writer.AppendOpenBracket();
 
             // Default instance
+            writer.WriteLines(EqualityComparerDefaultCodeComment);
             writer.WriteLine("public static EqualityComparer Default { get; } = new EqualityComparer();");
             writer.WriteLine();
 

--- a/Generator.Equals/Generators/StructEqualityGenerator.cs
+++ b/Generator.Equals/Generators/StructEqualityGenerator.cs
@@ -50,11 +50,13 @@ namespace Generator.Equals.Generators
             var symbolName = model.Fullname;
 
             writer.WriteLine();
+            writer.WriteLines(EqualityComparerCodeComment);
             writer.WriteLine(GeneratedCodeAttributeDeclaration);
             writer.WriteLine($"public sealed class EqualityComparer : global::System.Collections.Generic.IEqualityComparer<{symbolName}>");
             writer.AppendOpenBracket();
 
             // Default instance
+            writer.WriteLines(EqualityComparerDefaultCodeComment);
             writer.WriteLine("public static EqualityComparer Default { get; } = new EqualityComparer();");
             writer.WriteLine();
 


### PR DESCRIPTION
Fixes #76.

## Problem

Projects that enable `<GenerateDocumentationFile>true</GenerateDocumentationFile>` get CS1591 (*missing XML comment for publicly visible type or member*) on every type marked with `[Equatable]`. For projects that also treat warnings as errors on release builds, this makes them unbuildable.

```
global__TestClass.Generator.Equals.g.cs(65,25): warning CS1591: Missing XML comment for publicly visible type or member 'TestClass.EqualityComparer'
global__TestClass.Generator.Equals.g.cs(67,40): warning CS1591: Missing XML comment for publicly visible type or member 'TestClass.EqualityComparer.Default'
```

## Root cause

The generator documents everything else it emits — operators get `<summary>` blocks, overrides get `/// <inheritdoc/>`, `Inequalities` gets a full block — with exactly two exceptions: the nested `EqualityComparer` class declaration and its `Default` property.

I scanned all 218 snapshot files for public/protected members not preceded by a doc comment; only those two constructs came up (348 occurrences each), so nothing else in the generated output is affected.

This also explains the reported regression window. The nested comparer was introduced in `017206b` ("feat: support static equality comparer"), which first shipped in `4.0.0-alpha7`. 3.3.0 emitted only operators and overrides, all of which already had comments.

## Change

Two doc-comment constants in `EqualityGeneratorBase`, emitted at the four `BuildNestedEqualityComparer` sites (class, record, struct, record struct) — 18 added lines of generator source, plus the regenerated snapshots.

I used real doc comments rather than a `#pragma warning disable CS1591` header in the generated file, so the generated API stays documented for consumers and stays consistent with how the rest of the output is already written. Worth a look if you'd rather go the pragma route — it's a much smaller diff, at the cost of the comparer showing up undocumented in consumers' XML docs.

## Verification

- Repro project (`GenerateDocumentationFile=true`) reproduces the two warnings on `main` and builds with **0 warnings** with this change, checked across class, derived class, record, derived record, struct, and record struct.
- Full suite: **1375/1375 pass**. The 1156 behavioural tests were already green before the snapshots were regenerated, confirming the change is purely cosmetic.
- New regression test `XmlDocumentationTests` compiles all six supported type kinds with `DocumentationMode.Diagnose` — what `GenerateDocumentationFile` turns on — and asserts no CS1591. Confirmed it fails with the generator change reverted and passes with it.

## Reviewer notes

353 files changed, but only 5 are generator sources; the other 348 are mechanical `.verified.cs` snapshot updates, each adding the same two `<summary>` blocks. `Generator.Equals/` is the diff worth reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)