### PR TITLE
Enforce LF line endings across environments and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalise all text files to LF in the repository and in every checkout,
+# regardless of the contributor's core.autocrlf setting. Code-fix tests rely
+# on source files (and their raw string literals) being LF on disk.
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Verify line endings are LF
+      run: |
+        bad=$(git ls-files --eol | grep -E 'i/crlf|i/mixed' || true)
+        if [ -n "$bad" ]; then
+          echo "$bad"
+          echo "::error::Files with CRLF or mixed line endings are committed; this repository enforces LF (see .gitattributes)"
+          exit 1
+        fi
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/Generator.Equals.Tests/Analyzers/CodeFixTestBase.cs
+++ b/Generator.Equals.Tests/Analyzers/CodeFixTestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Testing;
 
 namespace Generator.Equals.Tests.Analyzers;
@@ -59,6 +60,12 @@ public abstract class CodeFixTestBase<TAnalyzer, TCodeFix>
             {
                 var project = solution.GetProject(projectId);
                 if (project == null) return solution;
+
+                // Pin the newline option to LF so code fixes produce identical output on
+                // every platform (the option defaults to Environment.NewLine). Source files
+                // are checked out as LF via .gitattributes, so expected sources are LF too.
+                solution = solution.WithOptions(solution.Options.WithChangedOption(
+                    FormattingOptions.NewLine, LanguageNames.CSharp, "\n"));
 
                 var compilationOptions = project.CompilationOptions;
                 if (compilationOptions != null)

--- a/Generator.Equals/Analyzers/CodeFixes/AddCollectionEqualityAttributeCodeFix.cs
+++ b/Generator.Equals/Analyzers/CodeFixes/AddCollectionEqualityAttributeCodeFix.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
 
 namespace Generator.Equals.Analyzers.CodeFixes;
 
@@ -140,9 +141,12 @@ public sealed class AddCollectionEqualityAttributeCodeFix : CodeFixProvider
         // If there were no attributes before, we need to handle the trivia correctly
         if (propertyDeclaration.AttributeLists.Count == 0)
         {
-            // Add newline after attribute list
+            // Add newline after attribute list, honouring the document's configured line ending
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var newLine = options.GetOption(FormattingOptions.NewLine);
+
             var lastAttr = newPropertyDeclaration.AttributeLists[newPropertyDeclaration.AttributeLists.Count - 1];
-            var updatedAttrList = lastAttr.WithTrailingTrivia(SyntaxFactory.LineFeed);
+            var updatedAttrList = lastAttr.WithTrailingTrivia(SyntaxFactory.EndOfLine(newLine));
             newPropertyDeclaration = newPropertyDeclaration.WithAttributeLists(
                 newPropertyDeclaration.AttributeLists.Replace(lastAttr, updatedAttrList));
 


### PR DESCRIPTION
## Summary

Replaces #81 by fixing the underlying environment problem rather than flipping the hard-coded newline.

On Windows checkouts with `core.autocrlf=true`, source files — including the raw string literals inside the code-fix tests — were converted to CRLF, while `AddCollectionEqualityAttributeCodeFix` emitted a hard-coded `SyntaxFactory.LineFeed`. The code-fix tests then failed only on those machines, which is exactly what @fraluderin hit in #81. Hard-coding CRLF instead would simply invert the failure onto LF systems.

This PR enforces the repository's existing all-LF style (581/581 tracked text files) at every layer:

- **`.gitattributes`** (`* text=auto eol=lf`): every checkout is LF on all platforms, overriding any local `core.autocrlf`. The index was already 100% LF, so `git add --renormalize .` is a no-op — no history churn.
- **`.editorconfig`** (`end_of_line = lf`): editors never introduce CRLF between checkout and commit.
- **CI check** in `test.yml`: fails the build if CRLF/mixed line endings are ever committed, guarding against future regressions (e.g. if `.gitattributes` is edited).
- **Code fix correctness**: `AddCollectionEqualityAttributeCodeFix` now derives its newline from `FormattingOptions.NewLine` instead of hard-coding `LineFeed`, so a real user invoking the fix in a CRLF file gets CRLF inserted, matching their configured line ending.
- **Deterministic tests**: `CodeFixTestBase` pins `FormattingOptions.NewLine` to `"\n"` (the option otherwise defaults to `Environment.NewLine`), so the code-fix tests produce identical output on every OS.

Existing contributors with CRLF working trees just need to refresh once after pulling:

```
git checkout main && git pull && git checkout-index --force --all
```

## Test plan

- Full test suite passes locally: 1408 passed, 0 failed
- `git ls-files --eol` verified free of `i/crlf`/`i/mixed` (the new CI check, run locally)
- `git add --renormalize .` confirmed a no-op

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)