### PR TITLE
Update docs for field comparison defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Below is a list of all supported comparers. Would you like something else added?
 This is the comparer that's used when a property has no attributes indicating otherwise. The generated code will use 
 ```EqualityComparer<T>.Default``` for both equals and hashing operation.
 
-> _Fields are not used in comparison unless explicitly annotated. To enable the default comparison for a field, annotate it with the `DefaultEquality` attribute._
+> _In v4+, fields are included in comparison by default, just like properties. Use `DefaultEquality` to opt a field in when `Explicit = true` is enabled._
 
 ### IgnoreEquality
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -34,7 +34,7 @@ Requires C# 9.0+. The type **must be `partial`**.
 
 | Attribute | Use When |
 |-----------|----------|
-| `[DefaultEquality]` | Default comparer. **Required on fields** (fields are excluded by default). |
+| `[DefaultEquality]` | Default comparer. |
 | `[IgnoreEquality]` | Skip this member |
 | `[OrderedEquality]` | Compare collection elements in order (like `SequenceEqual`) |
 | `[UnorderedEquality]` | Compare collection elements ignoring order |
@@ -87,9 +87,9 @@ partial class User
 }
 ```
 
-### Mark fields explicitly
+### Mark fields in explicit mode
 
-Fields are **not** included by default. You must annotate them:
+In v4+, fields are included by default, just like properties. When `[Equatable(Explicit = true)]` is enabled, annotate the fields you want compared:
 
 ```csharp
 [DefaultEquality]


### PR DESCRIPTION
The documentation still describes pre-v4 behavior for fields, stating they were excluded from equality unless explicitly annotated. This updates the docs to reflect v4+ semantics: fields participate in comparison by default, and `DefaultEquality` is only needed to opt members in under explicit mode.